### PR TITLE
ci: add SwiftSyntax version compatibility check #2

### DIFF
--- a/.github/workflows/check-macro-compatibility.yml
+++ b/.github/workflows/check-macro-compatibility.yml
@@ -1,0 +1,45 @@
+name: Check Macro Compatibility
+
+on: 
+  workflow_dispatch:
+    inputs:
+      run-tests:
+        description: 'Run tests during compatibility check'
+        type: boolean
+        default: true
+      major-versions-only:
+        description: 'Test only major versions (509.0.0, 510.0.0, 600.0.0)'
+        type: boolean
+        default: false
+      verbose:
+        description: 'Enable verbose output'
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      run-tests:
+        description: 'Run tests during compatibility check'
+        type: boolean
+        default: false
+      major-versions-only:
+        description: 'Test only major versions (509.0.0, 510.0.0, 600.0.0)'
+        type: boolean
+        default: true
+      verbose:
+        description: 'Enable verbose output'
+        type: boolean
+        default: false
+
+jobs:
+  check-macro-compatibility:
+    name: Check Macro Compatibility
+    runs-on: macos-15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run Swift Macro Compatibility Check
+        uses: Matejkob/swift-macro-compatibility-check@v1
+        with:
+          run-tests: ${{ inputs.run-tests }}
+          major-versions-only: ${{ inputs.major-versions-only }}
+          verbose: ${{ inputs.verbose }} 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,16 @@ jobs:
           fi
           echo "::endgroup::"
 
-  test:
+  check-macro-compatibility:
     needs: lint
+    uses: ./.github/workflows/check-macro-compatibility.yml
+    with:
+      run-tests: false
+      major-versions-only: true
+      verbose: false
+
+  test:
+    needs: check-macro-compatibility
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: macos-15
     steps:

--- a/Sources/FluentContentMacros/Parsers/MacroArgumentParser.swift
+++ b/Sources/FluentContentMacros/Parsers/MacroArgumentParser.swift
@@ -57,7 +57,7 @@ struct MacroArgumentParser {
     /// - Parameter declaration: The declaration to analyze
     /// - Returns: A ModelInfo containing the model's name, members, and access level
     static func extractModelDeclInfo(
-        declaration: some SwiftSyntax.DeclSyntaxProtocol
+        declaration: some DeclSyntaxProtocol
     ) -> ModelInfo {
         if let classDecl = declaration.as(ClassDeclSyntax.self) {
             let access = findAccessLevel(in: classDecl.modifiers)
@@ -67,7 +67,23 @@ struct MacroArgumentParser {
             let access = findAccessLevel(in: structDecl.modifiers)
             return (structDecl.name.text, structDecl.memberBlock, access)
         }
+        return ("", nil, "")
+    }
 
+    /// Extracts information about a model declaration.
+    /// - Parameter declaration: The declaration to analyze
+    /// - Returns: A ModelInfo containing the model's name, members, and access level
+    static func extractModelDeclInfo(
+        declaration: some DeclGroupSyntax
+    ) -> ModelInfo {
+        if let classDecl = declaration.as(ClassDeclSyntax.self) {
+            let access = findAccessLevel(in: classDecl.modifiers)
+            return (classDecl.name.text, classDecl.memberBlock, access)
+        }
+        if let structDecl = declaration.as(StructDeclSyntax.self) {
+            let access = findAccessLevel(in: structDecl.modifiers)
+            return (structDecl.name.text, structDecl.memberBlock, access)
+        }
         return ("", nil, "")
     }
 


### PR DESCRIPTION
- Add macro compatibility check job to test.yml
- Configure to run after lint but before tests
- Use major versions only for faster CI runs