### PR TITLE
refactor: convert IncludeRelations to OptionSet

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -15,14 +15,14 @@ The most common issue occurs when creating bidirectional relationships with opti
 
 ```swift
 // ❌ DON'T: Creates infinite size error
-@FluentContent(includeRelations: .both)
+@FluentContent(includeRelations: .all)  // Same as [.parent, .children]
 final class Author: Model {
     @ID var id: UUID?
     @OptionalChild(for: \.$author) var book: Book?  // Single optional relationship
     init() {}
 }
 
-@FluentContent(includeRelations: .both)
+@FluentContent(includeRelations: .all)  // Same as [.parent, .children]
 final class Book: Model {
     @ID var id: UUID?
     @Parent(key: "author_id") var author: Author    // Creates cycle
@@ -36,7 +36,7 @@ final class Book: Model {
 // }
 
 // ✅ DO: Use array relationships instead
-@FluentContent(includeRelations: .both)
+@FluentContent(includeRelations: .all)  // Same as [.parent, .children]
 final class Author: Model {
     @ID var id: UUID?
     @Children(for: \.$author) var books: [Book]     // Array breaks the cycle
@@ -48,26 +48,25 @@ final class Author: Model {
 //     let id: UUID?
 //     let books: [BookContent]
 // }
-```
 
 ### 2. Complex Relationship Cycles
 Multi-model cycles can create subtle issues:
 
 ```swift
 // ❌ DON'T: Three-way cycle with optional relationships
-@FluentContent(includeRelations: .both)
+@FluentContent(includeRelations: .all)  // Same as [.parent, .children]
 final class Student: Model {
     @OptionalParent(key: "advisor_id") var advisor: Professor?
     @OptionalChild(for: \.$student) var thesis: Thesis?
 }
 
-@FluentContent(includeRelations: .both)
+@FluentContent(includeRelations: .all)  // Same as [.parent, .children]
 final class Professor: Model {
     @Children(for: \.$advisor) var students: [Student]
     @OptionalChild(for: \.$reviewer) var reviewingThesis: Thesis?
 }
 
-@FluentContent(includeRelations: .both)
+@FluentContent(includeRelations: .all)  // Same as [.parent, .children]
 final class Thesis: Model {
     @Parent(key: "student_id") var student: Student
     @OptionalParent(key: "reviewer_id") var reviewer: Professor?
@@ -99,15 +98,15 @@ final class Student: Model {
 Self-referential models require special attention:
 
 ```swift
-// ❌ DON'T: Bidirectional self-reference with .both
-@FluentContent(includeRelations: .both)
+// ❌ DON'T: Bidirectional self-reference with .all
+@FluentContent(includeRelations: .all)  // Same as [.parent, .children]
 final class Employee: Model {
     @OptionalParent(key: "manager_id") var manager: Employee?
     @Children(for: \.$manager) var subordinates: [Employee]
 }
 
 // ✅ DO: Use selective inclusion or arrays
-@FluentContent(includeRelations: .children)
+@FluentContent(includeRelations: .children)  // Only include child relationships
 final class Employee: Model {
     @OptionalParent(key: "manager_id") var manager: Employee?
     @Children(for: \.$manager) var subordinates: [Employee]
@@ -125,7 +124,7 @@ final class Employee: Model {
 Array relationships provide the most reliable behavior:
 
 ```swift
-@FluentContent(includeRelations: .both)
+@FluentContent(includeRelations: .all)  // Same as [.parent, .children]
 final class Department: Model {
     @ID var id: UUID?
     @Children(for: \.$department) var employees: [Employee]
@@ -151,13 +150,13 @@ final class Employee: Model {
 Siblings relationships work exceptionally well:
 
 ```swift
-@FluentContent(includeRelations: .both)
+@FluentContent(includeRelations: .all)  // Same as [.parent, .children]
 final class Book: Model {
     @ID var id: UUID?
     @Siblings(through: BookTag.self, from: \.$book, to: \.$tag) var tags: [Tag]
 }
 
-@FluentContent(includeRelations: .both)
+@FluentContent(includeRelations: .all)  // Same as [.parent, .children]
 final class Tag: Model {
     @ID var id: UUID?
     @Siblings(through: BookTag.self, from: \.$tag, to: \.$book) var books: [Book]
@@ -185,13 +184,13 @@ final class Organization: Model {
     @Children(for: \.$organization) var departments: [Department]
 }
 
-@FluentContent(includeRelations: .both)
+@FluentContent(includeRelations: .all)  // Same as [.parent, .children]
 final class Department: Model {
     @Parent(key: "org_id") var organization: Organization
     @Children(for: \.$department) var teams: [Team]
 }
 
-@FluentContent(includeRelations: .both)
+@FluentContent(includeRelations: .all)  // Same as [.parent, .children]
 final class Team: Model {
     @Parent(key: "department_id") var department: Department
     @Children(for: \.$team) var members: [Employee]
@@ -216,7 +215,7 @@ final class Employee: Model {
 Safe handling of hierarchical self-references:
 
 ```swift
-@FluentContent(includeRelations: .both)
+@FluentContent(includeRelations: .all)  // Same as [.parent, .children]
 final class Category: Model {
     @ID var id: UUID?
     @OptionalParent(key: "parent_id") var parent: Category?
@@ -243,7 +242,7 @@ final class Category: Model {
 2. **Relationship Direction**
    - Choose a primary direction for relationships
    - Use selective inclusion (`.parent`, `.children`) strategically
-   - Avoid `.both` unless necessary
+   - Avoid `.all` unless necessary
 
 3. **Cycle Prevention**
    - Break cycles using array relationships

--- a/README.md
+++ b/README.md
@@ -99,10 +99,24 @@ final class Comment: Model {
 }
 
 // Include both parent and child relationships
-@FluentContent(includeRelations: .both)
+@FluentContent(includeRelations: .all)  // Same as [.parent, .children]
 final class Category: Model {
     @Parent(key: "parent_id") var parent: Category
     @Children(for: \.$parent) var subcategories: [Category]
+}
+
+// Include no relationships
+@FluentContent(includeRelations: .none)
+final class Settings: Model {
+    @Parent(key: "user_id") var user: User  // Will be ignored
+    @Children(for: \.$settings) var logs: [Log]  // Will be ignored
+}
+
+// Mix and match relationships
+@FluentContent(includeRelations: [.parent, .children])  // Same as .all
+final class CustomModel: Model {
+    @Parent(key: "parent_id") var parent: Parent
+    @Children(for: \.$parent) var children: [Child]
 }
 ```
 
@@ -218,7 +232,7 @@ Configure default behavior for all @FluentContent usages in your app:
 ```swift
 // In your app's setup code
 FluentContentDefaults.immutable = false        // Make all content types mutable by default
-FluentContentDefaults.includeRelations = .both // Include all relationships by default
+FluentContentDefaults.includeRelations = .all  // Include all relationships by default
 FluentContentDefaults.accessLevel = .internal  // Use internal access by default
 FluentContentDefaults.conformances = [.equatable, .hashable]  // Default protocol conformances
 

--- a/Sources/FluentContentMacroShared/Enums.swift
+++ b/Sources/FluentContentMacroShared/Enums.swift
@@ -1,15 +1,24 @@
 import Foundation
 
 /// Specifies which Fluent relationships should be included in the generated content.
-public enum IncludeRelations: Sendable {
-    /// Includes only parent relationships (e.g., `@Parent`, `@OptionalParent`).
-    case parent
+public struct IncludeRelations: OptionSet, Sendable {
+    public let rawValue: Int
 
-    /// Includes only child relationships (e.g., `@Children`, `@OptionalChild`, `@Siblings`).
-    case children
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    /// Includes parent relationships (e.g., `@Parent`, `@OptionalParent`).
+    public static let parent = IncludeRelations(rawValue: 1 << 0)
+
+    /// Includes child relationships (e.g., `@Children`, `@OptionalChild`, `@Siblings`).
+    public static let children = IncludeRelations(rawValue: 1 << 1)
 
     /// Includes both parent and child relationships.
-    case both
+    public static let all: IncludeRelations = [.parent, .children]
+
+    /// Includes no relationships.
+    public static let none: IncludeRelations = []
 }
 
 /// Defines the access level for the generated `Content` struct and `toContent()` method.

--- a/Sources/FluentContentMacros/Models/FluentRelationship.swift
+++ b/Sources/FluentContentMacros/Models/FluentRelationship.swift
@@ -11,13 +11,16 @@ enum FluentRelationship: String, CaseIterable {
 
     /// Returns relationship wrappers based on the IncludeRelations case
     static func wrappers(for includeRelations: IncludeRelations) -> [String] {
-        switch includeRelations {
-        case .parent:
-            [FluentRelationship.parent.rawValue, FluentRelationship.optionalParent.rawValue]
-        case .children:
-            [FluentRelationship.children.rawValue, FluentRelationship.optionalChild.rawValue, FluentRelationship.siblings.rawValue]
-        case .both:
-            FluentRelationship.allCases.map(\.rawValue)
+        var wrappers: [String] = []
+
+        if includeRelations.contains(.parent) {
+            wrappers += [FluentRelationship.parent.rawValue, FluentRelationship.optionalParent.rawValue]
         }
+
+        if includeRelations.contains(.children) {
+            wrappers += [FluentRelationship.children.rawValue, FluentRelationship.optionalChild.rawValue, FluentRelationship.siblings.rawValue]
+        }
+
+        return wrappers
     }
 }

--- a/Tests/FluentContentMacroTests/FluentContentMacroTests.swift
+++ b/Tests/FluentContentMacroTests/FluentContentMacroTests.swift
@@ -240,8 +240,8 @@
                 }
             }
 
-            @Test("Includes only parent relationships with fully qualified enum")
-            func includesOnlyParentRelationshipsWithFullEnum() {
+            @Test("Includes only parent relationships with fully qualified type")
+            func includesOnlyParentRelationshipsWithFullType() {
                 assertMacro {
                     """
                     @FluentContent(includeRelations: IncludeRelations.parent)
@@ -272,8 +272,8 @@
                 }
             }
 
-            @Test("Includes only child relationships with dot notation")
-            func includesOnlyChildRelationshipsWithDot() {
+            @Test("Includes only children relationships")
+            func includesOnlyChildrenRelationships() {
                 assertMacro {
                     """
                     @FluentContent(includeRelations: .children)
@@ -306,45 +306,11 @@
                 }
             }
 
-            @Test("Includes only child relationships with fully qualified enum")
-            func includesOnlyChildRelationshipsWithFullEnum() {
+            @Test("Includes both parent and children relationships with array syntax")
+            func includesBothRelationshipsWithArray() {
                 assertMacro {
                     """
-                    @FluentContent(includeRelations: IncludeRelations.children)
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                    }
-                    """
-                } expansion: {
-                    """
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                    }
-
-                    public struct PostContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let comments: [CommentContent]
-                    }
-
-                    extension Post {
-                        public func toContent() -> PostContent {
-                            .init(
-                                comments: comments.map {
-                                    $0.toContent()
-                                }
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-
-            @Test("Includes both relationships with dot notation")
-            func includesBothRelationshipsWithDot() {
-                assertMacro {
-                    """
-                    @FluentContent(includeRelations: .both)
+                    @FluentContent(includeRelations: [.parent, .children])
                     class Post {
                         @Parent(key: "author_id") var author: User
                         @Children(for: \\.$post) var comments: [Comment]
@@ -376,11 +342,11 @@
                 }
             }
 
-            @Test("Includes both relationships with fully qualified enum")
-            func includesBothRelationshipsWithFullEnum() {
+            @Test("Includes both parent and children relationships with .all")
+            func includesBothRelationshipsWithAll() {
                 assertMacro {
                     """
-                    @FluentContent(includeRelations: IncludeRelations.both)
+                    @FluentContent(includeRelations: .all)
                     class Post {
                         @Parent(key: "author_id") var author: User
                         @Children(for: \\.$post) var comments: [Comment]
@@ -405,6 +371,40 @@
                                 comments: comments.map {
                                     $0.toContent()
                                 }
+                            )
+                        }
+                    }
+                    """
+                }
+            }
+
+            @Test("Includes no relationships with .none")
+            func includesNoRelationshipsWithNone() {
+                assertMacro {
+                    """
+                    @FluentContent(includeRelations: .none)
+                    class Post {
+                        @Parent(key: "author_id") var author: User
+                        @Children(for: \\.$post) var comments: [Comment]
+                        var title: String
+                    }
+                    """
+                } expansion: {
+                    """
+                    class Post {
+                        @Parent(key: "author_id") var author: User
+                        @Children(for: \\.$post) var comments: [Comment]
+                        var title: String
+                    }
+
+                    public struct PostContent: CodableContent, Equatable, Hashable, Sendable {
+                        public let title: String
+                    }
+
+                    extension Post {
+                        public func toContent() -> PostContent {
+                            .init(
+                                title: title
                             )
                         }
                     }


### PR DESCRIPTION
- Change from enum to OptionSet
- Rename .both to .all
- Add .none option
- Support combining options like [.parent, .children]
- Update docs and tests