### PR TITLE
feat: Support Customizable DTO Naming for Generated Content Structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,27 @@ func getUser(_ req: Request) async throws -> UserContent {
 
 ## ⚙️ Configuration
 
+### Content Type Names
+Choose your preferred naming convention for generated types:
+```swift
+// Default behavior - generates UserContent, PostContent, etc.
+@FluentContent
+final class User: Model {
+    @ID var id: UUID?
+    @Field(key: "name") var name: String
+}
+
+// Custom suffix for specific models
+@FluentContent(contentSuffix: "DTO")  // Generates UserDTO with toDTO() method
+final class User: Model {
+    @ID var id: UUID?
+    @Field(key: "name") var name: String
+}
+
+// Global configuration (optional)
+FluentContentDefaults.contentSuffix = "Response"  // Changes default to UserResponse, PostResponse, etc.
+```
+
 ### Relationship Control
 Choose which relationships to include in your content structures:
 ```swift
@@ -235,9 +256,11 @@ FluentContentDefaults.immutable = false        // Make all content types mutable
 FluentContentDefaults.includeRelations = .all  // Include all relationships by default
 FluentContentDefaults.accessLevel = .internal  // Use internal access by default
 FluentContentDefaults.conformances = [.equatable, .hashable]  // Default protocol conformances
+FluentContentDefaults.contentSuffix = "Content"  // Default suffix for generated types (can be changed)
 
 // Individual @FluentContent attributes still override the defaults
 @FluentContent(immutable: true)  // This specific type will be immutable
+@FluentContent(contentSuffix: "DTO")  // This specific type will use DTO suffix
 ```
 
 ## 📚 Advanced Usage

--- a/Sources/FluentContentMacro/FluentContentMacro.swift
+++ b/Sources/FluentContentMacro/FluentContentMacro.swift
@@ -3,9 +3,10 @@ import FluentContentMacroShared
 /**
  A macro that generates a content representation of your Fluent model.
 
- This macro provides two main functionalities:
- 1. Generates a peer type with the name pattern `{ModelName}{Suffix}` (e.g., `UserContent` by default)
- 2. Adds a conversion method named `to{Suffix}()` (e.g., `toContent()` by default) via extension
+ This macro provides three main functionalities:
+ 1. Generates a nested type with the name pattern `{ModelName}{Suffix}` (e.g., `UserContent` by default)
+ 2. Adds a conversion method named `to{Suffix}()` (e.g., `toContent()` by default)
+ 3. Creates a typealias for easier access to the nested type (e.g., `typealias UserContent = Self.UserContent`)
 
  ## Features
  - Automatically includes normal fields (e.g. `@Field`, `@ID`)
@@ -18,17 +19,17 @@ import FluentContentMacroShared
  ## Parameters
 
  - **immutable**:
- If `true`, the generated struct uses `let` for its stored properties.
+ If `true`, the generated type uses `let` for its stored properties.
  If `false`, it uses `var`. Defaults to `true`.
 
  - **includeRelations**:
- Specifies which Fluent property wrappers should be transformed into nested content.
- Relationship wrappers (such as `@Children`, `@Parent`, etc.) generate nested types.
+ Specifies which Fluent property wrappers should be transformed into nested types.
+ Relationship wrappers (such as `@Children`, `@Parent`, etc.) generate nested types with the same suffix.
  Normal fields (e.g., `@Field`, `@ID`) are always included unless explicitly ignored with `@FluentContentIgnore`.
  Defaults to `.children`.
 
  - **accessLevel**:
- The desired access level for the generated struct and conversion method.
+ The desired access level for the generated type and conversion method.
  Defaults to `.public`, but you can specify `.internal`, `.fileprivate`, or `.private` to restrict visibility.
 
  - **conformances**:
@@ -36,10 +37,11 @@ import FluentContentMacroShared
  Defaults to all available protocols (Equatable, Hashable, Sendable).
 
  - **contentSuffix**:
- The suffix to use for the generated type and conversion method.
+ The suffix to use for generated types and conversion methods.
  For example, if set to "DTO", a User model would generate:
- - A UserDTO struct
+ - A nested UserDTO struct
  - A toDTO() conversion method
+ - A typealias UserDTO = Self.UserDTO
  Defaults to FluentContentDefaults.contentSuffix.
 
  ## Example Usage
@@ -54,7 +56,8 @@ import FluentContentMacroShared
 
  // Generates:
  public struct UserContent: CodableContent, Equatable, Hashable, Sendable { ... }
- extension User { public func toContent() -> UserContent { ... } }
+ public func toContent() -> UserContent { ... }
+ public typealias UserContent = Self.UserContent
 
  // Custom suffix example
  @FluentContent(contentSuffix: "DTO")
@@ -65,16 +68,17 @@ import FluentContentMacroShared
 
  // Generates:
  public struct UserDTO: CodableContent, Equatable, Hashable, Sendable { ... }
- extension User { public func toDTO() -> UserDTO { ... } }
+ public func toDTO() -> UserDTO { ... }
+ public typealias UserDTO = Self.UserDTO
  ```
  */
 @attached(member, names: arbitrary)
 public macro FluentContent(
-    /// If `true`, the generated struct uses `let` instead of `var`.
+    /// If `true`, the generated type uses `let` instead of `var`.
     immutable: Bool = FluentContentDefaults.immutable,
     /// Specifies which Fluent relationships to include in the generated content.
     includeRelations: IncludeRelations = FluentContentDefaults.includeRelations,
-    /// The desired access level for the generated struct and conversion method.
+    /// The desired access level for the generated type and conversion method.
     accessLevel: AccessLevel = FluentContentDefaults.accessLevel,
     /// The protocols that the generated type should conform to.
     /// Defaults to all available protocols (Equatable, Hashable, Sendable).

--- a/Sources/FluentContentMacro/FluentContentMacro.swift
+++ b/Sources/FluentContentMacro/FluentContentMacro.swift
@@ -68,8 +68,7 @@ import FluentContentMacroShared
  extension User { public func toDTO() -> UserDTO { ... } }
  ```
  */
-@attached(peer, names: arbitrary)
-@attached(extension, names: arbitrary)
+@attached(member, names: arbitrary)
 public macro FluentContent(
     /// If `true`, the generated struct uses `let` instead of `var`.
     immutable: Bool = FluentContentDefaults.immutable,

--- a/Sources/FluentContentMacroShared/Enums.swift
+++ b/Sources/FluentContentMacroShared/Enums.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Specifies which Fluent relationships should be included in the generated content.
+/// Specifies which Fluent relationships should be included in the generated type.
 public struct IncludeRelations: OptionSet, Sendable {
     public let rawValue: Int
 
@@ -21,7 +21,7 @@ public struct IncludeRelations: OptionSet, Sendable {
     public static let none: IncludeRelations = []
 }
 
-/// Defines the access level for the generated `Content` struct and `toContent()` method.
+/// Defines the access level for the generated type and conversion method.
 public enum AccessLevel: String, Sendable {
     /// Matches the access level of the model.
     case matchModel

--- a/Sources/FluentContentMacroShared/FluentContentDefaults.swift
+++ b/Sources/FluentContentMacroShared/FluentContentDefaults.swift
@@ -4,21 +4,26 @@ import Foundation
 /// You can modify these values to change the default settings for all @FluentContent usages in your project.
 @_nonSendable
 public enum FluentContentDefaults {
-    /// If `true`, the generated `Content` struct uses `let` for its stored properties.
+    /// If `true`, the generated type uses `let` for its stored properties.
     /// If `false`, it uses `var`. Defaults to `true`.
     nonisolated(unsafe) public static var immutable = true
 
-    /// Specifies which Fluent relationships should be included in the generated content.
-    /// Relationship wrappers (such as `@Children`, `@Parent`, etc.) generate nested `...Content` types.
+    /// Specifies which Fluent relationships should be included in the generated type.
+    /// Relationship wrappers (such as `@Children`, `@Parent`, etc.) generate nested types with the same suffix.
     /// Normal fields (e.g., `@Field`, `@ID`) are always included unless explicitly ignored with `@FluentContentIgnore`.
     /// Defaults to `.children`.
     nonisolated(unsafe) public static var includeRelations: IncludeRelations = .children
 
-    /// The desired access level for the generated `Content` struct and `toContent()` method.
+    /// The desired access level for the generated type and conversion method.
     /// Defaults to `.public`, but you can specify `.internal`, `.fileprivate`, or `.private` to restrict visibility.
     nonisolated(unsafe) public static var accessLevel: AccessLevel = .public
 
-    /// The protocols that the generated content should conform to.
+    /// The protocols that the generated type should conform to.
     /// Defaults to all available protocols (Equatable, Hashable, Sendable).
     nonisolated(unsafe) public static var conformances: ContentConformances = .all
+
+    /// The suffix to use for generated types and conversion methods.
+    /// For example, if set to "DTO", a User model would generate a UserDTO struct and toDTO() method.
+    /// Defaults to "Content".
+    nonisolated(unsafe) public static var contentSuffix: String = "Content"
 }

--- a/Sources/FluentContentMacros/Core/FluentContentMacro.swift
+++ b/Sources/FluentContentMacros/Core/FluentContentMacro.swift
@@ -7,8 +7,8 @@ import SwiftCompilerPlugin
  A macro that generates a content representation of your Fluent model.
 
  This macro provides two main functionalities:
- 1. Generates a `...Content` struct as a "peer" declaration that can be used for API responses
- 2. Adds a `toContent()` method via extension to easily convert model instances to their content representation
+ 1. Generates a peer type with the name pattern `{ModelName}{Suffix}` (e.g., `UserContent` by default)
+ 2. Adds a conversion method named `to{Suffix}()` (e.g., `toContent()` by default) via extension
 
  ## Features
  - Automatically includes normal fields (e.g. `@Field`, `@ID`)
@@ -16,50 +16,53 @@ import SwiftCompilerPlugin
  - Supports marking fields to ignore with `@FluentContentIgnore`
  - Configurable mutability with `immutable` parameter
  - Customizable access level
+ - Dynamic naming based on `contentSuffix`
 
  ## Parameters
- - **immutable**: If `true`, the generated `Content` struct uses `let` for its stored properties.
+ - **immutable**: If `true`, the generated type uses `let` for its stored properties.
    If `false`, it uses `var`. Defaults to `true`.
- - **includeRelations**: Specifies which Fluent property wrappers should be transformed into nested content.
-   Relationship wrappers (such as `@Children`, `@Parent`, etc.) generate nested `...Content` types.
+ - **includeRelations**: Specifies which Fluent property wrappers should be transformed into nested types.
+   Relationship wrappers (such as `@Children`, `@Parent`, etc.) generate nested types with the same suffix.
    Normal fields (e.g., `@Field`, `@ID`) are always included unless explicitly ignored with `@FluentContentIgnore`.
    Defaults to `.children`.
- - **accessLevel**: The desired access level for the generated `Content` struct and `toContent()` method.
+ - **accessLevel**: The desired access level for the generated type and conversion method.
    Defaults to `.public`, but you can specify `.internal`, `.fileprivate`, or `.private` to restrict visibility.
+ - **conformances**: The protocols that the generated type should conform to.
+   Defaults to all available protocols (Equatable, Hashable, Sendable).
+ - **contentSuffix**: The suffix to use for generated types and conversion methods.
+   For example, if set to "DTO", a User model would generate:
+   - A UserDTO struct
+   - A toDTO() conversion method
+   Defaults to FluentContentDefaults.contentSuffix.
 
  ## Example Usage
  ```swift
- @FluentContent(
-    immutable: true,
-    includeRelations: .children,
-    accessLevel: .public
- )
+ // Default behavior
+ @FluentContent
  public final class User: Model {
      @ID(key: .id) public var id: UUID?
      @Field(key: "username") public var username: String
      @Children(for: \.$user) var posts: [Post]
  }
 
- // The macro auto-generates:
- public struct UserContent: Content, Equatable {
-     public let id: UUID?
-     public let username: String
-     public let posts: [PostContent]
+ // Generates:
+ public struct UserContent: CodableContent, Equatable, Hashable, Sendable { ... }
+ extension User { public func toContent() -> UserContent { ... } }
+
+ // Custom suffix example
+ @FluentContent(contentSuffix: "DTO")
+ public final class User: Model {
+     @ID(key: .id) public var id: UUID?
+     @Field(key: "username") public var username: String
  }
 
- extension User {
-     public func toContent() -> UserContent {
-         .init(
-             id: id,
-             username: username,
-             posts: posts.map { $0.toContent() }
-         )
-     }
- }
+ // Generates:
+ public struct UserDTO: CodableContent, Equatable, Hashable, Sendable { ... }
+ extension User { public func toDTO() -> UserDTO { ... } }
  ```
  */
 public struct FluentContentMacro: PeerMacro, ExtensionMacro {
-    // MARK: - Peer Macro: Generate "...Content" struct
+    // MARK: - Peer Macro: Generate content struct
     /// Expands the macro to generate a peer content struct that mirrors the model's structure.
     /// - Parameters:
     ///   - node: The attribute syntax node representing the macro
@@ -71,32 +74,29 @@ public struct FluentContentMacro: PeerMacro, ExtensionMacro {
         providingPeersOf declaration: some SwiftSyntax.DeclSyntaxProtocol,
         in context: some SwiftSyntaxMacros.MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        // Parse the macro arguments => (immutable, includeRelations => [String])
-        let (isImmutable, includeRelations, accessLevel, conformances) = try MacroArgumentParser.parseMacroArguments(from: node)
+        let (isImmutable, includeRelations, accessLevel, conformances, contentSuffix) = try MacroArgumentParser.parseMacroArguments(from: node)
 
-        // Identify class or struct
         let (modelName, members, modelAccess) = MacroArgumentParser.extractModelDeclInfo(declaration: declaration)
         guard !modelName.isEmpty else {
             return []
         }
 
         let structAccess = accessLevel.resolvedAccessLevel(modelAccess: modelAccess)
-
-        // Build the "Content" struct
-        let contentName = "\(modelName)Content"
+        let contentName = "\(modelName)\(contentSuffix)"
         let props = PropertyExtractor.extractProperties(from: members, includeRelations: includeRelations)
         let structDecl = ContentStructBuilder.buildContentStruct(
             name: contentName,
             properties: props,
             access: structAccess,
             isImmutable: isImmutable,
-            conformances: conformances
+            conformances: conformances,
+            contentSuffix: contentSuffix
         )
 
         return [DeclSyntax(stringLiteral: structDecl)]
     }
 
-    // MARK: - Extension Macro: Generate `toContent()` Method
+    // MARK: - Extension Macro: Generate conversion method
     /// Expands the macro to add a `toContent()` method to the model.
     /// - Parameters:
     ///   - node: The attribute syntax node representing the macro
@@ -112,7 +112,7 @@ public struct FluentContentMacro: PeerMacro, ExtensionMacro {
         conformingTo protocols: [SwiftSyntax.TypeSyntax],
         in context: some SwiftSyntaxMacros.MacroExpansionContext
     ) throws -> [ExtensionDeclSyntax] {
-        let (_, includeRelations, accessLevel, _) = try MacroArgumentParser.parseMacroArguments(from: node)
+        let (_, includeRelations, accessLevel, _, contentSuffix) = try MacroArgumentParser.parseMacroArguments(from: node)
         let (modelName, members, modelAccess) = MacroArgumentParser.extractModelDeclInfo(declaration: declaration)
         guard !modelName.isEmpty else {
             return []
@@ -120,11 +120,15 @@ public struct FluentContentMacro: PeerMacro, ExtensionMacro {
 
         let methodAccess = accessLevel.resolvedAccessLevel(modelAccess: modelAccess)
         let props = PropertyExtractor.extractProperties(from: members, includeRelations: includeRelations)
-        let contentName = "\(modelName)Content"
+        let contentName = "\(modelName)\(contentSuffix)"
 
-        let methodDecl = ContentStructBuilder.buildToContentMethod(
+        // Generate method name based on suffix (e.g., toDTO() for DTO suffix)
+        let methodName = "to\(contentSuffix)"
+
+        let methodDecl = ContentStructBuilder.buildConversionMethod(
             properties: props,
             contentName: contentName,
+            methodName: methodName,
             access: methodAccess
         )
 

--- a/Sources/FluentContentMacros/Core/FluentContentMacro.swift
+++ b/Sources/FluentContentMacros/Core/FluentContentMacro.swift
@@ -75,7 +75,7 @@ public struct FluentContentMacro: MemberMacro {
         }
 
         let structAccess = accessLevel.resolvedAccessLevel(modelAccess: modelAccess)
-        let contentName = "\(contentSuffix)"
+        let contentName = "\(modelName)\(contentSuffix)"
         let props = PropertyExtractor.extractProperties(from: members, includeRelations: includeRelations)
         
         // Build the nested content struct
@@ -96,9 +96,13 @@ public struct FluentContentMacro: MemberMacro {
             access: structAccess
         )
 
+        // Build the typealias
+        let typealiasDecl = "\(structAccess) typealias \(contentName) = Self.\(contentName)"
+
         return [
             DeclSyntax(stringLiteral: structDecl),
-            DeclSyntax(stringLiteral: methodDecl)
+            DeclSyntax(stringLiteral: methodDecl),
+            DeclSyntax(stringLiteral: typealiasDecl)
         ]
     }
 }

--- a/Sources/FluentContentMacros/Core/FluentContentTypeAliasMacro.swift
+++ b/Sources/FluentContentMacros/Core/FluentContentTypeAliasMacro.swift
@@ -1,0 +1,44 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftSyntaxBuilder
+import FluentContentMacroShared
+
+public struct FluentContentTypeAliasMacro: DeclarationMacro {
+    public static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        // Get the declaration this macro is attached to
+        guard let declaration = node.parent?.parent?.as(ClassDeclSyntax.self) else {
+            return []
+        }
+        
+        let modelName = declaration.name.text
+        guard !modelName.isEmpty else {
+            return []
+        }
+        
+        // Find the @FluentContent attribute to get the contentSuffix
+        let contentSuffix = declaration.attributes.compactMap { attr -> String? in
+            guard let attr = attr.as(AttributeSyntax.self),
+                  attr.attributeName.description == "FluentContent" else {
+                return nil
+            }
+            
+            if let args = attr.arguments?.as(LabeledExprListSyntax.self) {
+                for arg in args where arg.label?.text == "contentSuffix" {
+                    if let stringLit = arg.expression.as(StringLiteralExprSyntax.self) {
+                        return stringLit.segments.first?.description ?? FluentContentDefaults.contentSuffix
+                    }
+                }
+            }
+            return FluentContentDefaults.contentSuffix
+        }.first ?? FluentContentDefaults.contentSuffix
+        
+        // Generate the typealias with the correct suffix
+        let typeName = "\(modelName)\(contentSuffix)"
+        let typealiasDecl = "public typealias \(typeName) = \(modelName).\(typeName)"
+        
+        return [DeclSyntax(stringLiteral: typealiasDecl)]
+    }
+} 

--- a/Sources/FluentContentMacros/Parsers/MacroArgumentParser.swift
+++ b/Sources/FluentContentMacros/Parsers/MacroArgumentParser.swift
@@ -8,7 +8,7 @@ import FluentContentMacroShared
 /// information from model declarations in the macro system.
 struct MacroArgumentParser {
     /// Configuration options parsed from macro arguments
-    typealias MacroConfig = (isImmutable: Bool, includeRelations: [String], accessLevel: AccessLevel, conformances: ContentConformances)
+    typealias MacroConfig = (isImmutable: Bool, includeRelations: [String], accessLevel: AccessLevel, conformances: ContentConformances, contentSuffix: String)
 
     /// Information about the model declaration being processed
     typealias ModelInfo = (name: String, members: MemberBlockSyntax?, accessLevel: String)
@@ -23,9 +23,10 @@ struct MacroArgumentParser {
         var relationNames = wrappersForCase(FluentContentDefaults.includeRelations)
         var accessLevel = FluentContentDefaults.accessLevel
         var conformances = FluentContentDefaults.conformances
+        var contentSuffix = FluentContentDefaults.contentSuffix
 
         guard let args = attr.arguments?.as(LabeledExprListSyntax.self) else {
-            return (isImmutable, relationNames, accessLevel, conformances)
+            return (isImmutable, relationNames, accessLevel, conformances, contentSuffix)
         }
 
         for arg in args {
@@ -47,10 +48,13 @@ struct MacroArgumentParser {
                 }
             } else if label == "conformances" {
                 conformances = try parseConformances(expr)
+            } else if label == "contentSuffix",
+                      let stringLit = expr.as(StringLiteralExprSyntax.self) {
+                contentSuffix = stringLit.segments.first?.description ?? FluentContentDefaults.contentSuffix
             }
         }
 
-        return (isImmutable, relationNames, accessLevel, conformances)
+        return (isImmutable, relationNames, accessLevel, conformances, contentSuffix)
     }
 
     /// Extracts information about a model declaration.

--- a/Sources/FluentContentMacros/Plugin.swift
+++ b/Sources/FluentContentMacros/Plugin.swift
@@ -1,0 +1,11 @@
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct FluentContentPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        FluentContentMacro.self,
+        FluentContentIgnoreMacro.self,
+        FluentContentTypeAliasMacro.self
+    ]
+} 

--- a/Tests/FluentContentMacroTests/FluentContentMacroTests.swift
+++ b/Tests/FluentContentMacroTests/FluentContentMacroTests.swift
@@ -5,14 +5,10 @@
     import FluentContentMacros
     import FluentContentMacroShared
 
-    @Suite(
-        .macros(
-            macros: [
-                "FluentContent": FluentContentMacro.self,
-                "FluentContentIgnore": FluentContentIgnoreMacro.self
-            ]
-        )
-    )
+    @Suite(.macros(macros: [
+        "FluentContent": FluentContentMacro.self,
+        "FluentContentIgnore": FluentContentIgnoreMacro.self
+    ]))
     struct FluentContentMacroTests {
         // MARK: - 1️⃣ Basic Functionality Tests
         @Suite("Basic Functionality")
@@ -74,454 +70,685 @@
                 }
             }
 
-            @Test("Handles all primitive types correctly")
-            func handlesPrimitiveTypes() {
-                assertMacro {
-                    """
-                    @FluentContent
-                    class AllPrimitives {
-                        var string: String
-                        var int: Int
-                        var double: Double
-                        var float: Float
-                        var bool: Bool
-                        var date: Date
-                        var uuid: UUID
-                        var data: Data
-                    }
-                    """
-                } expansion: {
-                    """
-                    class AllPrimitives {
-                        var string: String
-                        var int: Int
-                        var double: Double
-                        var float: Float
-                        var bool: Bool
-                        var date: Date
-                        var uuid: UUID
-                        var data: Data
-                    }
-
-                    public struct AllPrimitivesContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let string: String
-                        public let int: Int
-                        public let double: Double
-                        public let float: Float
-                        public let bool: Bool
-                        public let date: Date
-                        public let uuid: UUID
-                        public let data: Data
-                    }
-
-                    extension AllPrimitives {
-                        public func toContent() -> AllPrimitivesContent {
-                            .init(
-                                string: string,
-                                int: int,
-                                double: double,
-                                float: float,
-                                bool: bool,
-                                date: date,
-                                uuid: uuid,
-                                data: data
-                            )
+            @Suite("Type Handling")
+            struct TypeHandlingTests {
+                @Test("Handles all primitive types correctly")
+                func handlesPrimitiveTypes() {
+                    assertMacro {
+                        """
+                        @FluentContent
+                        class AllPrimitives {
+                            var string: String
+                            var int: Int
+                            var double: Double
+                            var float: Float
+                            var bool: Bool
+                            var date: Date
+                            var uuid: UUID
+                            var data: Data
                         }
+                        """
+                    } expansion: {
+                        """
+                        class AllPrimitives {
+                            var string: String
+                            var int: Int
+                            var double: Double
+                            var float: Float
+                            var bool: Bool
+                            var date: Date
+                            var uuid: UUID
+                            var data: Data
+                        }
+
+                        public struct AllPrimitivesContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let string: String
+                            public let int: Int
+                            public let double: Double
+                            public let float: Float
+                            public let bool: Bool
+                            public let date: Date
+                            public let uuid: UUID
+                            public let data: Data
+                        }
+
+                        extension AllPrimitives {
+                            public func toContent() -> AllPrimitivesContent {
+                                .init(
+                                    string: string,
+                                    int: int,
+                                    double: double,
+                                    float: float,
+                                    bool: bool,
+                                    date: date,
+                                    uuid: uuid,
+                                    data: data
+                                )
+                            }
+                        }
+                        """
                     }
-                    """
+                }
+
+                @Test("Handles optional and array types correctly")
+                func handlesOptionalAndArrayTypes() {
+                    assertMacro {
+                        """
+                        @FluentContent
+                        class User {
+                            var name: String?
+                            var tags: [String]
+                            var scores: [Int]?
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            var name: String?
+                            var tags: [String]
+                            var scores: [Int]?
+                        }
+
+                        public struct UserContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let name: String?
+                            public let tags: [String]
+                            public let scores: [Int]?
+                        }
+
+                        extension User {
+                            public func toContent() -> UserContent {
+                                .init(
+                                    name: name,
+                                    tags: tags,
+                                    scores: scores
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+
+                @Test("Handles complex nested types")
+                func handlesComplexNestedTypes() {
+                    assertMacro {
+                        """
+                        @FluentContent
+                        class ComplexModel {
+                            var simpleDict: [String: Int]
+                            var optArrayDict: [String: [Int]]?
+                            var arrayOptDict: [[String: Int?]]
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class ComplexModel {
+                            var simpleDict: [String: Int]
+                            var optArrayDict: [String: [Int]]?
+                            var arrayOptDict: [[String: Int?]]
+                        }
+
+                        public struct ComplexModelContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let simpleDict: [String: Int]
+                            public let optArrayDict: [String: [Int]]?
+                            public let arrayOptDict: [[String: Int?]]
+                        }
+
+                        extension ComplexModel {
+                            public func toContent() -> ComplexModelContent {
+                                .init(
+                                    simpleDict: simpleDict,
+                                    optArrayDict: optArrayDict,
+                                    arrayOptDict: arrayOptDict
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+
+                @Test("Handles nested optionals correctly")
+                func handlesNestedOptionals() {
+                    assertMacro {
+                        """
+                        @FluentContent
+                        class NestedOptionals {
+                            var maybeArray: [String?]?
+                            var arrayOfOptionals: [String?]
+                            var optionalArray: [String]?
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class NestedOptionals {
+                            var maybeArray: [String?]?
+                            var arrayOfOptionals: [String?]
+                            var optionalArray: [String]?
+                        }
+
+                        public struct NestedOptionalsContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let maybeArray: [String?]?
+                            public let arrayOfOptionals: [String?]
+                            public let optionalArray: [String]?
+                        }
+
+                        extension NestedOptionals {
+                            public func toContent() -> NestedOptionalsContent {
+                                .init(
+                                    maybeArray: maybeArray,
+                                    arrayOfOptionals: arrayOfOptionals,
+                                    optionalArray: optionalArray
+                                )
+                            }
+                        }
+                        """
+                    }
                 }
             }
 
-            @Test("Handles mutable properties when immutable: false")
-            func handlesMutableProperties() {
-                assertMacro {
-                    """
-                    @FluentContent(immutable: false)
-                    class MutableModel {
-                        var name: String
-                        var age: Int
-                    }
-                    """
-                } expansion: {
-                    """
-                    class MutableModel {
-                        var name: String
-                        var age: Int
-                    }
-
-                    public struct MutableModelContent: CodableContent, Equatable, Hashable, Sendable {
-                        public var name: String
-                        public var age: Int
-                    }
-
-                    extension MutableModel {
-                        public func toContent() -> MutableModelContent {
-                            .init(
-                                name: name,
-                                age: age
-                            )
+            @Suite("Property Mutability")
+            struct PropertyMutabilityTests {
+                @Test("Handles mutable properties when immutable: false")
+                func handlesMutableProperties() {
+                    assertMacro {
+                        """
+                        @FluentContent(immutable: false)
+                        class MutableModel {
+                            var name: String
+                            var age: Int
                         }
+                        """
+                    } expansion: {
+                        """
+                        class MutableModel {
+                            var name: String
+                            var age: Int
+                        }
+
+                        public struct MutableModelContent: CodableContent, Equatable, Hashable, Sendable {
+                            public var name: String
+                            public var age: Int
+                        }
+
+                        extension MutableModel {
+                            public func toContent() -> MutableModelContent {
+                                .init(
+                                    name: name,
+                                    age: age
+                                )
+                            }
+                        }
+                        """
                     }
-                    """
                 }
-            }
 
-            @Test("Handles optional and array types correctly")
-            func handlesOptionalAndArrayTypes() {
-                assertMacro {
-                    """
-                    @FluentContent
-                    class User {
-                        var name: String?
-                        var tags: [String]
-                        var scores: [Int]?
-                    }
-                    """
-                } expansion: {
-                    """
-                    class User {
-                        var name: String?
-                        var tags: [String]
-                        var scores: [Int]?
-                    }
-
-                    public struct UserContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let name: String?
-                        public let tags: [String]
-                        public let scores: [Int]?
-                    }
-
-                    extension User {
-                        public func toContent() -> UserContent {
-                            .init(
-                                name: name,
-                                tags: tags,
-                                scores: scores
-                            )
+                @Test("Uses immutable properties by default")
+                func usesImmutableByDefault() {
+                    assertMacro {
+                        """
+                        @FluentContent
+                        class User {
+                            var name: String
                         }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            var name: String
+                        }
+
+                        public struct UserContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let name: String
+                        }
+
+                        extension User {
+                            public func toContent() -> UserContent {
+                                .init(
+                                    name: name
+                                )
+                            }
+                        }
+                        """
                     }
-                    """
                 }
             }
         }
 
-        // MARK: - 2️⃣ Relationship Tests
+        // MARK: - 2️⃣ Content Suffix Tests
+        @Suite("Content Suffix")
+        struct ContentSuffixTests {
+            @Suite("Custom Suffix")
+            struct CustomSuffixTests {
+                @Test("Supports custom content suffix")
+                func supportsCustomContentSuffix() {
+                    assertMacro {
+                        """
+                        @FluentContent(contentSuffix: "DTO")
+                        class User {
+                            var name: String
+                            var age: Int
+                            @Children(for: \\.$user) var posts: [Post]
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            var name: String
+                            var age: Int
+                            @Children(for: \\.$user) var posts: [Post]
+                        }
+
+                        public struct UserDTO: CodableContent, Equatable, Hashable, Sendable {
+                            public let name: String
+                            public let age: Int
+                            public let posts: [PostDTO]
+                        }
+
+                        extension User {
+                            public func toDTO() -> UserDTO {
+                                .init(
+                                    name: name,
+                                    age: age,
+                                    posts: posts.map {
+                                        $0.toDTO()
+                                    }
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+
+                @Test("Handles relationships with custom suffix")
+                func handlesRelationshipsWithCustomSuffix() {
+                    assertMacro {
+                        """
+                        @FluentContent(contentSuffix: "Response", includeRelations: .all)
+                        class User {
+                            @Parent(key: "team_id") var team: Team
+                            @Children(for: \\.$user) var posts: [Post]
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            @Parent(key: "team_id") var team: Team
+                            @Children(for: \\.$user) var posts: [Post]
+                        }
+
+                        public struct UserResponse: CodableContent, Equatable, Hashable, Sendable {
+                            public let team: TeamResponse
+                            public let posts: [PostResponse]
+                        }
+
+                        extension User {
+                            public func toResponse() -> UserResponse {
+                                .init(
+                                    team: team.toResponse(),
+                                    posts: posts.map {
+                                        $0.toResponse()
+                                    }
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+            }
+
+            @Suite("Default Suffix")
+            struct DefaultSuffixTests {
+                @Test("Uses default content suffix when not specified")
+                func usesDefaultContentSuffix() {
+                    assertMacro {
+                        """
+                        @FluentContent(includeRelations: .parent)
+                        class User {
+                            var name: String
+                            @Parent(key: "team_id") var team: Team
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            var name: String
+                            @Parent(key: "team_id") var team: Team
+                        }
+
+                        public struct UserContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let name: String
+                            public let team: TeamContent
+                        }
+
+                        extension User {
+                            public func toContent() -> UserContent {
+                                .init(
+                                    name: name,
+                                    team: team.toContent()
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+
+                @Test("Handles relationships with default suffix")
+                func handlesRelationshipsWithDefaultSuffix() {
+                    assertMacro {
+                        """
+                        @FluentContent(includeRelations: .parent)
+                        class User {
+                            var name: String
+                            @Parent(key: "team_id") var team: Team
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            var name: String
+                            @Parent(key: "team_id") var team: Team
+                        }
+
+                        public struct UserContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let name: String
+                            public let team: TeamContent
+                        }
+
+                        extension User {
+                            public func toContent() -> UserContent {
+                                .init(
+                                    name: name,
+                                    team: team.toContent()
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+            }
+        }
+
+        // MARK: - 3️⃣ Relationship Tests
         @Suite("Relationship Handling")
         struct RelationshipTests {
-            @Test("Includes only parent relationships with dot notation")
-            func includesOnlyParentRelationshipsWithDot() {
-                assertMacro {
-                    """
-                    @FluentContent(includeRelations: .parent)
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                    }
-                    """
-                } expansion: {
-                    """
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                    }
-
-                    public struct PostContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let author: UserContent
-                    }
-
-                    extension Post {
-                        public func toContent() -> PostContent {
-                            .init(
-                                author: author.toContent()
-                            )
+            @Suite("Parent Relationships")
+            struct ParentRelationshipTests {
+                @Test("Includes only parent relationships with dot notation")
+                func includesOnlyParentRelationshipsWithDot() {
+                    assertMacro {
+                        """
+                        @FluentContent(includeRelations: .parent)
+                        class Post {
+                            @Parent(key: "author_id") var author: User
+                            @Children(for: \\.$post) var comments: [Comment]
                         }
+                        """
+                    } expansion: {
+                        """
+                        class Post {
+                            @Parent(key: "author_id") var author: User
+                            @Children(for: \\.$post) var comments: [Comment]
+                        }
+
+                        public struct PostContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let author: UserContent
+                        }
+
+                        extension Post {
+                            public func toContent() -> PostContent {
+                                .init(
+                                    author: author.toContent()
+                                )
+                            }
+                        }
+                        """
                     }
-                    """
+                }
+
+                @Test("Includes only parent relationships with fully qualified type")
+                func includesOnlyParentRelationshipsWithFullType() {
+                    assertMacro {
+                        """
+                        @FluentContent(includeRelations: IncludeRelations.parent)
+                        class Post {
+                            @Parent(key: "author_id") var author: User
+                            @Children(for: \\.$post) var comments: [Comment]
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class Post {
+                            @Parent(key: "author_id") var author: User
+                            @Children(for: \\.$post) var comments: [Comment]
+                        }
+
+                        public struct PostContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let author: UserContent
+                        }
+
+                        extension Post {
+                            public func toContent() -> PostContent {
+                                .init(
+                                    author: author.toContent()
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+
+                @Test("Handles optional parent relationships")
+                func handlesOptionalParentRelationships() {
+                    assertMacro {
+                        """
+                        @FluentContent(includeRelations: .parent)
+                        class Comment {
+                            @OptionalParent(key: "post_id") var post: Post?
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class Comment {
+                            @OptionalParent(key: "post_id") var post: Post?
+                        }
+
+                        public struct CommentContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let post: PostContent?
+                        }
+
+                        extension Comment {
+                            public func toContent() -> CommentContent {
+                                .init(
+                                    post: post?.toContent()
+                                )
+                            }
+                        }
+                        """
+                    }
                 }
             }
 
-            @Test("Includes only parent relationships with fully qualified type")
-            func includesOnlyParentRelationshipsWithFullType() {
-                assertMacro {
-                    """
-                    @FluentContent(includeRelations: IncludeRelations.parent)
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                    }
-                    """
-                } expansion: {
-                    """
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                    }
-
-                    public struct PostContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let author: UserContent
-                    }
-
-                    extension Post {
-                        public func toContent() -> PostContent {
-                            .init(
-                                author: author.toContent()
-                            )
+            @Suite("Children Relationships")
+            struct ChildrenRelationshipTests {
+                @Test("Includes only children relationships")
+                func includesOnlyChildrenRelationships() {
+                    assertMacro {
+                        """
+                        @FluentContent(includeRelations: .children)
+                        class Post {
+                            @Parent(key: "author_id") var author: User
+                            @Children(for: \\.$post) var comments: [Comment]
                         }
+                        """
+                    } expansion: {
+                        """
+                        class Post {
+                            @Parent(key: "author_id") var author: User
+                            @Children(for: \\.$post) var comments: [Comment]
+                        }
+
+                        public struct PostContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let comments: [CommentContent]
+                        }
+
+                        extension Post {
+                            public func toContent() -> PostContent {
+                                .init(
+                                    comments: comments.map {
+                                        $0.toContent()
+                                    }
+                                )
+                            }
+                        }
+                        """
                     }
-                    """
+                }
+
+                @Test("Handles siblings relationships")
+                func handlesSiblingsRelationships() {
+                    assertMacro {
+                        """
+                        @FluentContent(includeRelations: .children)
+                        class User {
+                            @Siblings(through: UserRole.self, from: \\.$user, to: \\.$role)
+                            var roles: [Role]
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            @Siblings(through: UserRole.self, from: \\.$user, to: \\.$role)
+                            var roles: [Role]
+                        }
+
+                        public struct UserContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let roles: [RoleContent]
+                        }
+
+                        extension User {
+                            public func toContent() -> UserContent {
+                                .init(
+                                    roles: roles.map {
+                                        $0.toContent()
+                                    }
+                                )
+                            }
+                        }
+                        """
+                    }
                 }
             }
 
-            @Test("Includes only children relationships")
-            func includesOnlyChildrenRelationships() {
-                assertMacro {
-                    """
-                    @FluentContent(includeRelations: .children)
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                    }
-                    """
-                } expansion: {
-                    """
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                    }
-
-                    public struct PostContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let comments: [CommentContent]
-                    }
-
-                    extension Post {
-                        public func toContent() -> PostContent {
-                            .init(
-                                comments: comments.map {
-                                    $0.toContent()
-                                }
-                            )
+            @Suite("Combined Relationships")
+            struct CombinedRelationshipTests {
+                @Test("Includes both parent and children relationships with array syntax")
+                func includesBothRelationshipsWithArray() {
+                    assertMacro {
+                        """
+                        @FluentContent(includeRelations: [.parent, .children])
+                        class Post {
+                            @Parent(key: "author_id") var author: User
+                            @Children(for: \\.$post) var comments: [Comment]
                         }
+                        """
+                    } expansion: {
+                        """
+                        class Post {
+                            @Parent(key: "author_id") var author: User
+                            @Children(for: \\.$post) var comments: [Comment]
+                        }
+
+                        public struct PostContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let author: UserContent
+                            public let comments: [CommentContent]
+                        }
+
+                        extension Post {
+                            public func toContent() -> PostContent {
+                                .init(
+                                    author: author.toContent(),
+                                    comments: comments.map {
+                                        $0.toContent()
+                                    }
+                                )
+                            }
+                        }
+                        """
                     }
-                    """
                 }
-            }
 
-            @Test("Includes both parent and children relationships with array syntax")
-            func includesBothRelationshipsWithArray() {
-                assertMacro {
-                    """
-                    @FluentContent(includeRelations: [.parent, .children])
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                    }
-                    """
-                } expansion: {
-                    """
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                    }
-
-                    public struct PostContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let author: UserContent
-                        public let comments: [CommentContent]
-                    }
-
-                    extension Post {
-                        public func toContent() -> PostContent {
-                            .init(
-                                author: author.toContent(),
-                                comments: comments.map {
-                                    $0.toContent()
-                                }
-                            )
+                @Test("Includes both parent and children relationships with .all")
+                func includesBothRelationshipsWithAll() {
+                    assertMacro {
+                        """
+                        @FluentContent(includeRelations: .all)
+                        class Post {
+                            @Parent(key: "author_id") var author: User
+                            @Children(for: \\.$post) var comments: [Comment]
                         }
+                        """
+                    } expansion: {
+                        """
+                        class Post {
+                            @Parent(key: "author_id") var author: User
+                            @Children(for: \\.$post) var comments: [Comment]
+                        }
+
+                        public struct PostContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let author: UserContent
+                            public let comments: [CommentContent]
+                        }
+
+                        extension Post {
+                            public func toContent() -> PostContent {
+                                .init(
+                                    author: author.toContent(),
+                                    comments: comments.map {
+                                        $0.toContent()
+                                    }
+                                )
+                            }
+                        }
+                        """
                     }
-                    """
                 }
-            }
 
-            @Test("Includes both parent and children relationships with .all")
-            func includesBothRelationshipsWithAll() {
-                assertMacro {
-                    """
-                    @FluentContent(includeRelations: .all)
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                    }
-                    """
-                } expansion: {
-                    """
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                    }
-
-                    public struct PostContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let author: UserContent
-                        public let comments: [CommentContent]
-                    }
-
-                    extension Post {
-                        public func toContent() -> PostContent {
-                            .init(
-                                author: author.toContent(),
-                                comments: comments.map {
-                                    $0.toContent()
-                                }
-                            )
+                @Test("Includes no relationships with .none")
+                func includesNoRelationshipsWithNone() {
+                    assertMacro {
+                        """
+                        @FluentContent(includeRelations: .none)
+                        class Post {
+                            @Parent(key: "author_id") var author: User
+                            @Children(for: \\.$post) var comments: [Comment]
+                            var title: String
                         }
-                    }
-                    """
-                }
-            }
-
-            @Test("Includes no relationships with .none")
-            func includesNoRelationshipsWithNone() {
-                assertMacro {
-                    """
-                    @FluentContent(includeRelations: .none)
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                        var title: String
-                    }
-                    """
-                } expansion: {
-                    """
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                        var title: String
-                    }
-
-                    public struct PostContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let title: String
-                    }
-
-                    extension Post {
-                        public func toContent() -> PostContent {
-                            .init(
-                                title: title
-                            )
+                        """
+                    } expansion: {
+                        """
+                        class Post {
+                            @Parent(key: "author_id") var author: User
+                            @Children(for: \\.$post) var comments: [Comment]
+                            var title: String
                         }
-                    }
-                    """
-                }
-            }
 
-            @Test("Handles optional relationships correctly")
-            func handlesOptionalRelationships() {
-                assertMacro {
-                    """
-                    @FluentContent(includeRelations: .parent)
-                    class Comment {
-                        @OptionalParent(key: "post_id") var post: Post?
-                    }
-                    """
-                } expansion: {
-                    """
-                    class Comment {
-                        @OptionalParent(key: "post_id") var post: Post?
-                    }
-
-                    public struct CommentContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let post: PostContent?
-                    }
-
-                    extension Comment {
-                        public func toContent() -> CommentContent {
-                            .init(
-                                post: post?.toContent()
-                            )
+                        public struct PostContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let title: String
                         }
-                    }
-                    """
-                }
-            }
 
-            @Test("Handles siblings relationships")
-            func handlesSiblingsRelationships() {
-                assertMacro {
-                    """
-                    @FluentContent(includeRelations: .children)
-                    class User {
-                        @Siblings(through: UserRole.self, from: \\.$user, to: \\.$role)
-                        var roles: [Role]
-                    }
-                    """
-                } expansion: {
-                    """
-                    class User {
-                        @Siblings(through: UserRole.self, from: \\.$user, to: \\.$role)
-                        var roles: [Role]
-                    }
-
-                    public struct UserContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let roles: [RoleContent]
-                    }
-
-                    extension User {
-                        public func toContent() -> UserContent {
-                            .init(
-                                roles: roles.map {
-                                    $0.toContent()
-                                }
-                            )
+                        extension Post {
+                            public func toContent() -> PostContent {
+                                .init(
+                                    title: title
+                                )
+                            }
                         }
+                        """
                     }
-                    """
-                }
-            }
-
-            @Test("Includes non-relationship properties with custom wrappers")
-            func includesNonRelationshipProperties() {
-                assertMacro {
-                    """
-                    @FluentContent(includeRelations: .parent)
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                        @CustomWrapper var title: String
-                        @Timestamp var createdAt: Date
-                        var normalProperty: String
-                    }
-                    """
-                } expansion: {
-                    """
-                    class Post {
-                        @Parent(key: "author_id") var author: User
-                        @Children(for: \\.$post) var comments: [Comment]
-                        @CustomWrapper var title: String
-                        @Timestamp var createdAt: Date
-                        var normalProperty: String
-                    }
-
-                    public struct PostContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let author: UserContent
-                        public let title: String
-                        public let createdAt: Date
-                        public let normalProperty: String
-                    }
-
-                    extension Post {
-                        public func toContent() -> PostContent {
-                            .init(
-                                author: author.toContent(),
-                                title: title,
-                                createdAt: createdAt,
-                                normalProperty: normalProperty
-                            )
-                        }
-                    }
-                    """
                 }
             }
         }
 
-        // MARK: - 3️⃣ Access Level Tests
+        // MARK: - 4️⃣ Access Level Tests
         @Suite("Access Level")
         struct AccessLevelTests {
             @Test("Matches model's access level")
@@ -645,7 +872,290 @@
             }
         }
 
-        // MARK: - 4️⃣ Ignore Attribute Tests
+        // MARK: - 5️⃣ Protocol Conformance Tests
+        @Suite("Protocol Conformances")
+        struct ProtocolConformanceTests {
+            @Suite("Default Conformances")
+            struct DefaultConformanceTests {
+                @Test("Default conformances include all protocols")
+                func defaultConformancesIncludeAll() {
+                    assertMacro {
+                        """
+                        @FluentContent
+                        class User {
+                            var name: String
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            var name: String
+                        }
+
+                        public struct UserContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let name: String
+                        }
+
+                        extension User {
+                            public func toContent() -> UserContent {
+                                .init(
+                                    name: name
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+            }
+
+            @Suite("Single Protocol")
+            struct SingleProtocolTests {
+                @Test("Can specify only Equatable conformance")
+                func onlyEquatableConformance() {
+                    assertMacro {
+                        """
+                        @FluentContent(conformances: .equatable)
+                        class User {
+                            var name: String
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            var name: String
+                        }
+
+                        public struct UserContent: CodableContent, Equatable {
+                            public let name: String
+                        }
+
+                        extension User {
+                            public func toContent() -> UserContent {
+                                .init(
+                                    name: name
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+
+                @Test("Can specify only Hashable conformance")
+                func onlyHashableConformance() {
+                    assertMacro {
+                        """
+                        @FluentContent(conformances: .hashable)
+                        class User {
+                            var name: String
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            var name: String
+                        }
+
+                        public struct UserContent: CodableContent, Hashable {
+                            public let name: String
+                        }
+
+                        extension User {
+                            public func toContent() -> UserContent {
+                                .init(
+                                    name: name
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+
+                @Test("Can specify only Sendable conformance")
+                func onlySendableConformance() {
+                    assertMacro {
+                        """
+                        @FluentContent(conformances: .sendable)
+                        class User {
+                            var name: String
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            var name: String
+                        }
+
+                        public struct UserContent: CodableContent, Sendable {
+                            public let name: String
+                        }
+
+                        extension User {
+                            public func toContent() -> UserContent {
+                                .init(
+                                    name: name
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+            }
+
+            @Suite("Combined Protocols")
+            struct CombinedProtocolTests {
+                @Test("Can specify Equatable and Hashable conformance")
+                func equatableAndHashableConformance() {
+                    assertMacro {
+                        """
+                        @FluentContent(conformances: [.equatable, .hashable])
+                        class User {
+                            var name: String
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            var name: String
+                        }
+
+                        public struct UserContent: CodableContent, Equatable, Hashable {
+                            public let name: String
+                        }
+
+                        extension User {
+                            public func toContent() -> UserContent {
+                                .init(
+                                    name: name
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+
+                @Test("Can specify Equatable and Sendable conformance")
+                func equatableAndSendableConformance() {
+                    assertMacro {
+                        """
+                        @FluentContent(conformances: [.equatable, .sendable])
+                        class User {
+                            var name: String
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            var name: String
+                        }
+
+                        public struct UserContent: CodableContent, Equatable, Sendable {
+                            public let name: String
+                        }
+
+                        extension User {
+                            public func toContent() -> UserContent {
+                                .init(
+                                    name: name
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+
+                @Test("Can specify Hashable and Sendable conformance")
+                func hashableAndSendableConformance() {
+                    assertMacro {
+                        """
+                        @FluentContent(conformances: [.hashable, .sendable])
+                        class User {
+                            var name: String
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            var name: String
+                        }
+
+                        public struct UserContent: CodableContent, Hashable, Sendable {
+                            public let name: String
+                        }
+
+                        extension User {
+                            public func toContent() -> UserContent {
+                                .init(
+                                    name: name
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+
+                @Test("Can specify all conformances explicitly")
+                func allConformancesExplicitly() {
+                    assertMacro {
+                        """
+                        @FluentContent(conformances: [.equatable, .hashable, .sendable])
+                        class User {
+                            var name: String
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            var name: String
+                        }
+
+                        public struct UserContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let name: String
+                        }
+
+                        extension User {
+                            public func toContent() -> UserContent {
+                                .init(
+                                    name: name
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+
+                @Test("Can specify all conformances using .all")
+                func allConformancesUsingAll() {
+                    assertMacro {
+                        """
+                        @FluentContent(conformances: .all)
+                        class User {
+                            var name: String
+                        }
+                        """
+                    } expansion: {
+                        """
+                        class User {
+                            var name: String
+                        }
+
+                        public struct UserContent: CodableContent, Equatable, Hashable, Sendable {
+                            public let name: String
+                        }
+
+                        extension User {
+                            public func toContent() -> UserContent {
+                                .init(
+                                    name: name
+                                )
+                            }
+                        }
+                        """
+                    }
+                }
+            }
+        }
+
+        // MARK: - 6️⃣ Ignore Attribute Tests
         @Suite("Ignore Attribute")
         struct IgnoreAttributeTests {
             @Test("Ignores fields marked with @FluentContentIgnore")
@@ -733,538 +1243,6 @@
                             .init(
                                 id: id,
                                 username: username,
-                                posts: posts.map {
-                                    $0.toContent()
-                                }
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-        }
-
-        // MARK: - 5️⃣ Edge Cases & Error Handling
-        @Suite("Edge Cases")
-        struct EdgeCaseTests {
-            @Test("Handles empty struct with relationships")
-            func handlesEmptyStructWithRelationships() {
-                assertMacro {
-                    """
-                    @FluentContent(includeRelations: .children)
-                    class EmptyWithRelations {
-                        @Children(for: \\.$parent) var children: [Child]
-                    }
-                    """
-                } expansion: {
-                    """
-                    class EmptyWithRelations {
-                        @Children(for: \\.$parent) var children: [Child]
-                    }
-
-                    public struct EmptyWithRelationsContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let children: [ChildContent]
-                    }
-
-                    extension EmptyWithRelations {
-                        public func toContent() -> EmptyWithRelationsContent {
-                            .init(
-                                children: children.map {
-                                    $0.toContent()
-                                }
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-
-            @Test("Handles complex nested types")
-            func handlesComplexNestedTypes() {
-                assertMacro {
-                    """
-                    @FluentContent
-                    class ComplexModel {
-                        var simpleDict: [String: Int]
-                        var optArrayDict: [String: [Int]]?
-                        var arrayOptDict: [[String: Int?]]
-                    }
-                    """
-                } expansion: {
-                    """
-                    class ComplexModel {
-                        var simpleDict: [String: Int]
-                        var optArrayDict: [String: [Int]]?
-                        var arrayOptDict: [[String: Int?]]
-                    }
-
-                    public struct ComplexModelContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let simpleDict: [String: Int]
-                        public let optArrayDict: [String: [Int]]?
-                        public let arrayOptDict: [[String: Int?]]
-                    }
-
-                    extension ComplexModel {
-                        public func toContent() -> ComplexModelContent {
-                            .init(
-                                simpleDict: simpleDict,
-                                optArrayDict: optArrayDict,
-                                arrayOptDict: arrayOptDict
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-
-            @Test("Handles nested optionals correctly")
-            func handlesNestedOptionals() {
-                assertMacro {
-                    """
-                    @FluentContent
-                    class NestedOptionals {
-                        var maybeArray: [String?]?
-                        var arrayOfOptionals: [String?]
-                        var optionalArray: [String]?
-                    }
-                    """
-                } expansion: {
-                    """
-                    class NestedOptionals {
-                        var maybeArray: [String?]?
-                        var arrayOfOptionals: [String?]
-                        var optionalArray: [String]?
-                    }
-
-                    public struct NestedOptionalsContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let maybeArray: [String?]?
-                        public let arrayOfOptionals: [String?]
-                        public let optionalArray: [String]?
-                    }
-
-                    extension NestedOptionals {
-                        public func toContent() -> NestedOptionalsContent {
-                            .init(
-                                maybeArray: maybeArray,
-                                arrayOfOptionals: arrayOfOptionals,
-                                optionalArray: optionalArray
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-
-            @Test("Handles all Fluent field wrappers")
-            func handlesAllFluentFieldWrappers() {
-                assertMacro {
-                    """
-                    @FluentContent
-                    final class AllWrappers: Model {
-                        @ID(key: .id)
-                        var id: UUID?
-
-                        @Field(key: "name")
-                        var name: String
-
-                        @Enum(key: "status")
-                        var status: Status
-
-                        @Group(key: "metadata")
-                        var metadata: Metadata
-
-                        @Timestamp(key: "created_at", on: .create)
-                        var createdAt: Date?
-
-                        @CompositeID
-                        var compositeId: CompositeID
-                    }
-                    """
-                } expansion: {
-                    """
-                    final class AllWrappers: Model {
-                        @ID(key: .id)
-                        var id: UUID?
-
-                        @Field(key: "name")
-                        var name: String
-
-                        @Enum(key: "status")
-                        var status: Status
-
-                        @Group(key: "metadata")
-                        var metadata: Metadata
-
-                        @Timestamp(key: "created_at", on: .create)
-                        var createdAt: Date?
-
-                        @CompositeID
-                        var compositeId: CompositeID
-                    }
-
-                    public struct AllWrappersContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let id: UUID?
-                        public let name: String
-                        public let status: Status
-                        public let metadata: Metadata
-                        public let createdAt: Date?
-                        public let compositeId: CompositeID
-                    }
-
-                    extension AllWrappers {
-                        public func toContent() -> AllWrappersContent {
-                            .init(
-                                id: id,
-                                name: name,
-                                status: status,
-                                metadata: metadata,
-                                createdAt: createdAt,
-                                compositeId: compositeId
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-        }
-
-        // MARK: - Protocol Conformance Tests
-        @Suite("Protocol Conformances")
-        struct ProtocolConformanceTests {
-            @Test("Default conformances include all protocols")
-            func defaultConformancesIncludeAll() {
-                assertMacro {
-                    """
-                    @FluentContent
-                    class User {
-                        var name: String
-                    }
-                    """
-                } expansion: {
-                    """
-                    class User {
-                        var name: String
-                    }
-
-                    public struct UserContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let name: String
-                    }
-
-                    extension User {
-                        public func toContent() -> UserContent {
-                            .init(
-                                name: name
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-
-            @Test("Can specify only Equatable conformance")
-            func onlyEquatableConformance() {
-                assertMacro {
-                    """
-                    @FluentContent(conformances: .equatable)
-                    class User {
-                        var name: String
-                    }
-                    """
-                } expansion: {
-                    """
-                    class User {
-                        var name: String
-                    }
-
-                    public struct UserContent: CodableContent, Equatable {
-                        public let name: String
-                    }
-
-                    extension User {
-                        public func toContent() -> UserContent {
-                            .init(
-                                name: name
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-
-            @Test("Can specify only Hashable conformance")
-            func onlyHashableConformance() {
-                assertMacro {
-                    """
-                    @FluentContent(conformances: .hashable)
-                    class User {
-                        var name: String
-                    }
-                    """
-                } expansion: {
-                    """
-                    class User {
-                        var name: String
-                    }
-
-                    public struct UserContent: CodableContent, Hashable {
-                        public let name: String
-                    }
-
-                    extension User {
-                        public func toContent() -> UserContent {
-                            .init(
-                                name: name
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-
-            @Test("Can specify only Sendable conformance")
-            func onlySendableConformance() {
-                assertMacro {
-                    """
-                    @FluentContent(conformances: .sendable)
-                    class User {
-                        var name: String
-                    }
-                    """
-                } expansion: {
-                    """
-                    class User {
-                        var name: String
-                    }
-
-                    public struct UserContent: CodableContent, Sendable {
-                        public let name: String
-                    }
-
-                    extension User {
-                        public func toContent() -> UserContent {
-                            .init(
-                                name: name
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-
-            @Test("Can specify Equatable and Hashable conformance")
-            func equatableAndHashableConformance() {
-                assertMacro {
-                    """
-                    @FluentContent(conformances: [.equatable, .hashable])
-                    class User {
-                        var name: String
-                    }
-                    """
-                } expansion: {
-                    """
-                    class User {
-                        var name: String
-                    }
-
-                    public struct UserContent: CodableContent, Equatable, Hashable {
-                        public let name: String
-                    }
-
-                    extension User {
-                        public func toContent() -> UserContent {
-                            .init(
-                                name: name
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-
-            @Test("Can specify Equatable and Sendable conformance")
-            func equatableAndSendableConformance() {
-                assertMacro {
-                    """
-                    @FluentContent(conformances: [.equatable, .sendable])
-                    class User {
-                        var name: String
-                    }
-                    """
-                } expansion: {
-                    """
-                    class User {
-                        var name: String
-                    }
-
-                    public struct UserContent: CodableContent, Equatable, Sendable {
-                        public let name: String
-                    }
-
-                    extension User {
-                        public func toContent() -> UserContent {
-                            .init(
-                                name: name
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-
-            @Test("Can specify Hashable and Sendable conformance")
-            func hashableAndSendableConformance() {
-                assertMacro {
-                    """
-                    @FluentContent(conformances: [.hashable, .sendable])
-                    class User {
-                        var name: String
-                    }
-                    """
-                } expansion: {
-                    """
-                    class User {
-                        var name: String
-                    }
-
-                    public struct UserContent: CodableContent, Hashable, Sendable {
-                        public let name: String
-                    }
-
-                    extension User {
-                        public func toContent() -> UserContent {
-                            .init(
-                                name: name
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-
-            @Test("Can specify all conformances explicitly")
-            func allConformancesExplicitly() {
-                assertMacro {
-                    """
-                    @FluentContent(conformances: [.equatable, .hashable, .sendable])
-                    class User {
-                        var name: String
-                    }
-                    """
-                } expansion: {
-                    """
-                    class User {
-                        var name: String
-                    }
-
-                    public struct UserContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let name: String
-                    }
-
-                    extension User {
-                        public func toContent() -> UserContent {
-                            .init(
-                                name: name
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-
-            @Test("Can specify all conformances using .all")
-            func allConformancesUsingAll() {
-                assertMacro {
-                    """
-                    @FluentContent(conformances: .all)
-                    class User {
-                        var name: String
-                    }
-                    """
-                } expansion: {
-                    """
-                    class User {
-                        var name: String
-                    }
-
-                    public struct UserContent: CodableContent, Equatable, Hashable, Sendable {
-                        public let name: String
-                    }
-
-                    extension User {
-                        public func toContent() -> UserContent {
-                            .init(
-                                name: name
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-
-            @Test("Can specify no additional conformances")
-            func noAdditionalConformances() {
-                assertMacro {
-                    """
-                    @FluentContent(conformances: .none)
-                    class User {
-                        var name: String
-                    }
-                    """
-                } expansion: {
-                    """
-                    class User {
-                        var name: String
-                    }
-
-                    public struct UserContent: CodableContent {
-                        public let name: String
-                    }
-
-                    extension User {
-                        public func toContent() -> UserContent {
-                            .init(
-                                name: name
-                            )
-                        }
-                    }
-                    """
-                }
-            }
-
-            @Test("Handles complex types with specific conformances")
-            func complexTypesWithSpecificConformances() {
-                assertMacro {
-                    """
-                    @FluentContent(conformances: [.equatable, .hashable])
-                    class User {
-                        var name: String?
-                        var age: Int
-                        var tags: [String]
-                        @Children(for: \\.$user) var posts: [Post]
-                    }
-                    """
-                } expansion: {
-                    """
-                    class User {
-                        var name: String?
-                        var age: Int
-                        var tags: [String]
-                        @Children(for: \\.$user) var posts: [Post]
-                    }
-
-                    public struct UserContent: CodableContent, Equatable, Hashable {
-                        public let name: String?
-                        public let age: Int
-                        public let tags: [String]
-                        public let posts: [PostContent]
-                    }
-
-                    extension User {
-                        public func toContent() -> UserContent {
-                            .init(
-                                name: name,
-                                age: age,
-                                tags: tags,
                                 posts: posts.map {
                                     $0.toContent()
                                 }


### PR DESCRIPTION
Adds contentSuffix parameter to @FluentContent macro allowing customization of generated type names while maintaining "Content" as the default suffix. This enables better integration with different architectural patterns and naming conventions.

Resolves #1